### PR TITLE
fix(ci): extract export template archive directly to specified directory

### DIFF
--- a/.github/workflows/export-godot-target.yaml
+++ b/.github/workflows/export-godot-target.yaml
@@ -137,12 +137,13 @@ jobs:
 
       # ----------------------------- Export the target ---------------------------- #
 
-      # Extract macOS SDK
+      # Download and extract export template.
       - name: Download 'godot' export template
         uses: actions/download-artifact@v4
         with:
           name: ${{ needs.build.outputs.path }}
           path: ${{ runner.temp }}/${{ needs.build.outputs.path }}
+          merge-multiple: true
 
       - name: Export the target
         uses: ./.github/actions/export-gdbuild-target


### PR DESCRIPTION
Fixes incorrect paths for export templates built from prior workflows.