### PR TITLE
fix(compile): specify `-Wno-c99-designator` to ignore warning seen during cross-compilation for `macos`

### DIFF
--- a/compile-godot-export-template/macos/Dockerfile
+++ b/compile-godot-export-template/macos/Dockerfile
@@ -242,11 +242,4 @@ ENV SCONSFLAGS="$SCONSFLAGS angle_libs=/opt/angle"
 # NOTE: As of Godot 4.0.3, the 'SCons' configuration does not correctly
 # detect clang usage via 'OSXCross'. Add in the missing compiler flags and
 # "common warnings" here (see https://github.com/godotengine/godot/blob/2267646bf4c29acf1342951d8726626817c742bd/SConstruct#L727-L730).
-ENV CCFLAGS="-Wno-ordered-compare-function-pointers"
-
-# NOTE: It's unclear why 'arm64' builds fail using this toolchain setup. Disabling
-# the 'c99-designator' thus unblocks builds. Perhaps this is because we don't
-# use Apple clang? Consider building Apple clang to prevent inconsistencies. 
-ENV CCFLAGS="$CCFLAGS -Wno-c99-designator"
-
-ENV SCONSFLAGS="$SCONSFLAGS CC=clang CXX=clang++ ccflags=\"$CCFLAGS\""
+ENV SCONSFLAGS="$SCONSFLAGS CC=clang CXX=clang++ ccflags=-Wno-ordered-compare-function-pointers"

--- a/compile-godot-export-template/macos/action.yml
+++ b/compile-godot-export-template/macos/action.yml
@@ -36,6 +36,12 @@ inputs:
 runs:
   using: docker
   image: docker://ghcr.io/coffeebeats/compile-godot-export-template:godot-v4.4-macos
+  env:
+    # NOTE: It's unclear why 'arm64' builds fail using this toolchain setup (is Godot
+    # not cross-compiled regularly?). Disabling the 'c99-designator' warning unblocks
+    # builds for now. Note that multiple 'ccflags' cannot be passed in via 'SCONSFLAGS',
+    # so pass it in via a command line argument.
+    CCFLAGS: "-Wno-ordered-compare-function-pointers -Wno-c99-designator"
   args:
     - /bin/bash
     - -c
@@ -55,6 +61,7 @@ runs:
       cache_path=/github/workspace/${{ inputs.scons-cache-path }}
       arch=${{ inputs.arch }}
       verbose=yes warnings=extra werror=yes
+      ccflags="$CCFLAGS"
       $([[ "${{ inputs.use-double-precision }}" == 'true' ]] && echo "precision=double")
       $([[ "${{ inputs.profile }}" == "debug" ]] && echo target=template_debug debug_symbols=yes optimize=debug)
       $([[ "${{ inputs.profile }}" == "release_debug" ]] && echo target=template_debug production=yes debug_symbols=yes optimize=speed_trace)


### PR DESCRIPTION
This should address the following error seen during cross-compilation for `macos` on `linux`:

```
drivers/metal/pixel_formats.mm:562:41: error: mixture of designated and non-designated initializers in the same initializer list is a C99 extension [-Werror,-Wc99-designator]
  562 |         _mtl_pixel_format_descs[p_pix_fmt] = { .mtlPixelFormat = p_pix_fmt, DataFormat::DATA_FORMAT_MAX, p_fmt_caps, p_view_class, p_pix_fmt_linear, p_name };
      |                                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~
drivers/metal/pixel_formats.mm:562:70: note: first non-designated initializer is here
  562 |         _mtl_pixel_format_descs[p_pix_fmt] = { .mtlPixelFormat = p_pix_fmt, DataFormat::DATA_FORMAT_MAX, p_fmt_caps, p_view_class, p_pix_fmt_linear, p_name };
      |                                                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~
drivers/metal/pixel_formats.mm:763:42: error: mixture of designated and non-designated initializers in the same initializer list is a C99 extension [-Werror,-Wc99-designator]
  763 |         _mtl_vertex_format_descs[mtlVtxFmt] = { .mtlVertexFormat = mtlVtxFmt, RD::DATA_FORMAT_MAX, vtxCap, MTLViewClass::None, MTLPixelFormatInvalid, name };
      |                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
drivers/metal/pixel_formats.mm:763:72: note: first non-designated initializer is here
  763 |         _mtl_vertex_format_descs[mtlVtxFmt] = { .mtlVertexFormat = mtlVtxFmt, RD::DATA_FORMAT_MAX, vtxCap, MTLViewClass::None, MTLPixelFormatInvalid, name };
      |                                                                               ^~~~~~~~~~~~~~~~~~~
2 errors generated.
scons: *** [drivers/metal/pixel_formats.macos.template_release.arm64.o] Error 1
drivers/metal/rendering_device_driver_metal.mm:3123:3: error: array designators are a C99 extension [-Werror,-Wc99-designator]
 3123 |                 [ATTACHMENT_LOAD_OP_LOAD] = MTLLoadActionLoad,
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~
drivers/metal/rendering_device_driver_metal.mm:3129:3: error: array designators are a C99 extension [-Werror,-Wc99-designator]
 3129 |                 [ATTACHMENT_STORE_OP_STORE] = MTLStoreActionStore,
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~
2 errors generated.
scons: *** [drivers/metal/rendering_device_driver_metal.macos.template_release.arm64.o] Error 1
drivers/metal/metal_objects.mm:1924:2: error: array designators are a C99 extension [-Werror,-Wc99-designator]
 1924 |         [RD::SHADER_STAGE_VERTEX] = "vert",
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
scons: *** [drivers/metal/metal_objects.macos.template_release.arm64.o] Error 1
scons: building terminated because of errors.
```