### PR TITLE
fix(ci): Revert "use `godot-infra` actions via local path (#499)"

### DIFF
--- a/.github/actions/check-code-formatting/action.yml
+++ b/.github/actions/check-code-formatting/action.yml
@@ -35,7 +35,7 @@ runs:
 
         ${{ inputs.fix-command }}
 
-    - uses: ./commit-changes
+    - uses: coffeebeats/godot-infra/commit-changes@v4
       if: steps.check-formatting.outcome == 'failure'
       with:
         description: "fix formatting"

--- a/.github/actions/install-godot-source/action.yml
+++ b/.github/actions/install-godot-source/action.yml
@@ -111,7 +111,7 @@ runs:
 
     - name: Determine the Godot version
       id: godot
-      uses: ./.github/actions/parse-godot-version
+      uses: coffeebeats/godot-infra/.github/actions/parse-godot-version@v4
       with:
         fail-on-requirements-not-met: false
         versionpy-path: ${{ github.workspace }}/godot-${{ inputs.godot-src-rev }}/version.py

--- a/check-godot-project/action.yaml
+++ b/check-godot-project/action.yaml
@@ -26,7 +26,7 @@ runs:
       shell: bash
       run: pip install "gdtoolkit==4.*"
 
-    - uses: ./.github/actions/check-code-formatting
+    - uses: "coffeebeats/godot-infra/.github/actions/check-code-formatting@v4"
       with:
         check-command: "gdformat -l ${{ inputs.line-length-max }} --check ${{ inputs.path }}/**/*.gd"
         fix-command: "gdformat -l ${{ inputs.line-length-max }} ${{ inputs.path }}/**/*.gd"

--- a/compile-godot-export-template/action.yml
+++ b/compile-godot-export-template/action.yml
@@ -116,7 +116,7 @@ runs:
 
     # --------------------- Vendor the Godot source code --------------------- #
 
-    - uses: ./.github/actions/install-godot-source
+    - uses: coffeebeats/godot-infra/.github/actions/install-godot-source@v4
       with:
         dst-path: ${{ github.workspace }}/godot
         godot-src-rev: ${{ inputs.godot-src-rev }}
@@ -124,7 +124,7 @@ runs:
         godot-patches: ${{ inputs.godot-patches }}
 
     - name: Parse Godot source code version
-      uses: ./.github/actions/parse-godot-version
+      uses: "coffeebeats/godot-infra/.github/actions/parse-godot-version@v4"
       with:
         versionpy-path: ${{ github.workspace }}/godot/version.py
         minimum-major-version: 4
@@ -265,7 +265,7 @@ runs:
         inputs.platform == 'macos' &&
         (inputs.arch == 'x86_64' || inputs.arch == 'universal') &&
         steps.godot-cache.outputs.cache-hit != 'true'
-      uses: ./compile-godot-export-template/macos
+      uses: "coffeebeats/godot-infra/compile-godot-export-template/macos@v4"
       with:
         app-bundle: ${{ inputs.arch == 'x86_64' }}
         arch: x86_64
@@ -280,7 +280,7 @@ runs:
         inputs.platform == 'macos'  &&
         (inputs.arch == 'arm64' || inputs.arch == 'universal') &&
         steps.godot-cache.outputs.cache-hit != 'true'
-      uses: ./compile-godot-export-template/macos
+      uses: "coffeebeats/godot-infra/compile-godot-export-template/macos@v4"
       with:
         app-bundle: true
         arch: arm64
@@ -298,7 +298,7 @@ runs:
         inputs.compile-editor != 'true' &&
         inputs.platform == 'web' &&
         steps.godot-cache.outputs.cache-hit != 'true'
-      uses: ./compile-godot-export-template/web
+      uses: "coffeebeats/godot-infra/compile-godot-export-template/web@v4"
       with:
         arch: ${{ inputs.arch }}
         enable-gdextension: ${{ inputs.enable-gdextension }}
@@ -315,7 +315,7 @@ runs:
       if: |
         inputs.platform == 'windows' &&
         steps.godot-cache.outputs.cache-hit != 'true'
-      uses: ./compile-godot-export-template/windows
+      uses: "coffeebeats/godot-infra/compile-godot-export-template/windows@v4"
       with:
         arch: ${{ inputs.arch }}
         encryption-key: ${{ inputs.encryption-key }}

--- a/export-godot-project-preset/action.yaml
+++ b/export-godot-project-preset/action.yaml
@@ -99,14 +99,14 @@ runs:
         EDITOR_PATH=$(mktemp -d -p ${{ github.workspace }})
         echo "path=${EDITOR_PATH#${{ github.workspace }}/}" >> $GITHUB_OUTPUT
 
-    - uses: ./.github/actions/setup-godot
+    - uses: coffeebeats/godot-infra/.github/actions/setup-godot@v4
       with:
         version: ${{ inputs.godot-editor-version }}
         install-dir: ${{ steps.editor.outputs.path }}
 
     # TODO: Consider removing this and using the input editor version instead.
     - name: Parse Godot editor version
-      uses: ./.github/actions/parse-godot-version
+      uses: "coffeebeats/godot-infra/.github/actions/parse-godot-version@v4"
       id: godot-version
       with:
         editor-path: ${{ steps.editor.outputs.path }}/bin/godot
@@ -154,7 +154,7 @@ runs:
         echo "path=${TARGET#${{ github.workspace }}/}" >> $GITHUB_OUTPUT
 
     - name: Set path to export template in 'export_presets.cfg'
-      uses: ./inspect-godot-export-presets
+      uses: coffeebeats/godot-infra/inspect-godot-export-presets@v4
       with:
         project-path: ${{ github.workspace }}/${{ steps.project.outputs.dir }}
         operation: "set"
@@ -165,7 +165,7 @@ runs:
     # ---------------------- Configure export properties --------------------- #
 
     - name: Get the configured preset platform
-      uses: ./inspect-godot-export-presets
+      uses: coffeebeats/godot-infra/inspect-godot-export-presets@v4
       id: preset-platform
       with:
         project-path: ${{ github.workspace }}/${{ steps.project.outputs.dir }}
@@ -191,7 +191,7 @@ runs:
         echo "Determined platform for preset '${{ inputs.preset-name }}': $PLATFORM"
 
     - name: Get the configured preset export path
-      uses: ./inspect-godot-export-presets
+      uses: coffeebeats/godot-infra/inspect-godot-export-presets@v4
       id: preset-export-path
       with:
         project-path: ${{ github.workspace }}/${{ steps.project.outputs.dir }}
@@ -233,7 +233,7 @@ runs:
 
     - name: Export the Godot project preset (MacOS)
       if: steps.platform.outputs.value == 'macos'
-      uses: ./export-godot-project-preset/macos
+      uses: "coffeebeats/godot-infra/export-godot-project-preset/macos@v4"
       with:
         pck-only: ${{ inputs.pck-only == 'true' || endsWith(steps.export-path.outputs.value, '.pck') }}
         preset-name: ${{ inputs.preset-name }}
@@ -259,7 +259,7 @@ runs:
 
     - name: Export the Godot project preset (Web)
       if: steps.platform.outputs.value == 'web'
-      uses: ./export-godot-project-preset/web
+      uses: "coffeebeats/godot-infra/export-godot-project-preset/web@v4"
       with:
         pck-only: ${{ inputs.pck-only == 'true' || endsWith(steps.export-path.outputs.value, '.pck') }}
         preset-name: ${{ inputs.preset-name }}
@@ -275,7 +275,7 @@ runs:
 
     - name: Export the Godot project preset (Windows)
       if: steps.platform.outputs.value == 'windows'
-      uses: ./export-godot-project-preset/windows
+      uses: "coffeebeats/godot-infra/export-godot-project-preset/windows@v4"
       with:
         pck-only: ${{ inputs.pck-only == 'true' || endsWith(steps.export-path.outputs.value, '.pck') }}
         preset-name: ${{ inputs.preset-name }}

--- a/package-addon/action.yaml
+++ b/package-addon/action.yaml
@@ -28,7 +28,7 @@ runs:
       shell: bash
       run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
-    - uses: ./.github/actions/setup-godot
+    - uses: coffeebeats/godot-infra/.github/actions/setup-godot@v4
       with:
         version: ${{ inputs.godot-editor-version }}
 
@@ -195,7 +195,7 @@ runs:
         echo "Target addon workspace (after):"
         tree -lha --dirsfirst -I .git
 
-    - uses: ./commit-changes
+    - uses: coffeebeats/godot-infra/commit-changes@v4
       with:
         description: "updating \\`${{ inputs.subfolder }}\\` to ${{ steps.commit.outputs.sha_short }}"
         target-branch: ${{ inputs.target-branch }}

--- a/publish-project-itchio/action.yml
+++ b/publish-project-itchio/action.yml
@@ -21,7 +21,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: ./.github/actions/setup-butler
+    - uses: coffeebeats/godot-infra/.github/actions/setup-butler@v4
 
     - name: Log in to itch.io
       shell: bash


### PR DESCRIPTION
This reverts commit 138c2e3aa91f6fbd58f0db7e37eec95f42499c21.

This is because when an external repository references one of these actions _that have transitive dependencies on local `godot-infra` actions_, because the `godot-infra` repository isn't checked out that consumer won't be able to resolve the action.
